### PR TITLE
Replace theme background with gradient in CrmDashboard

### DIFF
--- a/src/crm/CrmDashboard.tsx
+++ b/src/crm/CrmDashboard.tsx
@@ -45,9 +45,7 @@ export default function CrmDashboard() {
           component="main"
           sx={(theme) => ({
             flexGrow: 1,
-            backgroundColor: theme.vars
-              ? `rgba(${theme.vars.palette.background.defaultChannel} / 1)`
-              : alpha(theme.palette.background.default, 1),
+            background: "linear-gradient(135deg, #e91e63 0%, #9c27b0 100%)",
             overflow: "auto",
           })}
         >


### PR DESCRIPTION
Replace the theme-based background color with a fixed linear gradient in the CrmDashboard component.

Changes:
- Remove conditional theme background color logic
- Add linear gradient background (135deg, pink to purple)
- Simplify the sx prop styling

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/aba0390b27b0452980a388523ebbe52f/mystic-realm)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>aba0390b27b0452980a388523ebbe52f</projectId>-->
<!--<branchName>mystic-realm</branchName>-->