### PR TITLE
Add top margin to CrmStatCard value typography

### DIFF
--- a/src/crm/components/CrmStatCard.tsx
+++ b/src/crm/components/CrmStatCard.tsx
@@ -86,7 +86,12 @@ export default function CrmStatCard({
               direction="row"
               sx={{ justifyContent: "space-between", alignItems: "center" }}
             >
-              <Typography variant="h4" component="p" fontWeight="600">
+              <Typography
+                variant="h4"
+                component="p"
+                fontWeight="600"
+                sx={{ marginTop: "14px" }}
+              >
                 {value}
               </Typography>
               <Chip


### PR DESCRIPTION
Adds a 14px top margin to the Typography component displaying the value in CrmStatCard.

The Typography component props have been reformatted across multiple lines and a new sx prop with marginTop: "14px" has been added.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 15`

🔗 [Edit in Builder.io](https://builder.io/app/projects/aba0390b27b0452980a388523ebbe52f/swoosh-field)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>aba0390b27b0452980a388523ebbe52f</projectId>-->
<!--<branchName>swoosh-field</branchName>-->